### PR TITLE
Add iframe auto-resizing

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -3,45 +3,53 @@
 var Promise = TrelloPowerUp.Promise;
 var t = TrelloPowerUp.iframe();
 
-// Show remove button and currently stored values if habitTrackerSettings exists
-t.get('card', 'shared', 'habitTrackerSettings')
-.then(function(habitTrackerSettings) {
-  if (habitTrackerSettings) {
-    document.getElementById('remove-btn').classList.remove('u-hidden');
-        
-    document.querySelectorAll("#settings_form [name='daysInWeek']")[0].value = habitTrackerSettings.daysInWeek;
-    document.querySelectorAll("#settings_form [name='firstDayOfWeek']")[0].value = habitTrackerSettings.firstDayOfWeek;
-  }
-}).catch(function(){
-     // do nothing
-  });
+t.render(function () {
+  // make sure your rendering logic lives here, since we will
+  // recall this method when data is changed that the Power-Up might care
+  // about like data stored via t.set
+
+  // Show remove button and currently stored values if habitTrackerSettings exists
+  t.get('card', 'shared', 'habitTrackerSettings')
+    .then(function (habitTrackerSettings) {
+      if (habitTrackerSettings) {
+        document.getElementById('remove-btn').classList.remove('u-hidden');
+
+        document.querySelectorAll("#settings_form [name='daysInWeek']")[0].value = habitTrackerSettings.daysInWeek;
+        document.querySelectorAll("#settings_form [name='firstDayOfWeek']")[0].value = habitTrackerSettings.firstDayOfWeek;
+      }
+    }).catch(function () {
+      // do nothing
+    }).finally(function () {
+      t.sizeTo(document.body);
+    });
+});
 
 // Stores settings in habitTrackerSettings when user presses save button
-document.getElementById('save-btn').addEventListener('click', function(){
-  
+document.getElementById('save-btn').addEventListener('click', function (){
+
   const daysInWeek = document.querySelectorAll("#settings_form [name='daysInWeek']")[0].value;
   const firstDayOfWeek = document.querySelectorAll("#settings_form [name='firstDayOfWeek']")[0].value;
-  
+
   return t.set('card', 'shared', 'habitTrackerSettings', {daysInWeek, firstDayOfWeek})
-  .then(function(){
+  .then(function (){
     t.closePopup();
-  }).catch(function(){
+  }).catch(function (){
       // do nothing
   });
 });
 
 // Removes habitTrackerSettings when user presses remove button
-document.getElementById('remove-btn').addEventListener('click', function(){
+document.getElementById('remove-btn').addEventListener('click', function (){
   return t.set('card', 'shared', 'habitTrackerSettings', null)
-        .then(function(){
-          t.closePopup();
-        }).catch(function(){
-            // do nothing
-        });
+    .then(function (){
+      t.closePopup();
+    }).catch(function (){
+        // do nothing
+    });
 });
 
 // Brings up information modal when user clicks "How to use Streak"
-document.getElementById('how-to-use').addEventListener('click', function(){
+document.getElementById('how-to-use').addEventListener('click', function (){
   return t.modal({
     url: './modal.html',
     height: 360,


### PR DESCRIPTION
Because the content of the t.popup may change based on styles in Trello
changing, we should resize the iframe using t.sizeTo automatically so
that it is always the correct height.

This PR adds in two things:

- `t.render()` - https://developers.trello.com/reference#t-render - The function passed to `t.render` will be called whenever data that the Power-Up may care about changes. For instance, if two users were using the Power-Up at the same time and one of them saved the preferences on a board, you'd want the other user's view to be updated with the new information. Now, if that happens, the iframe will be re-rendered and the new data will be used.
- `t.sizeTo()` - https://developers.trello.com/reference#t-sizeto - This allows you to let Trello be responsible for making sure the height of the iframe is correct. It gets you out of the game of trying to calculate what the correct height is when you open the popup.